### PR TITLE
Compile fix for visual studio.

### DIFF
--- a/example/matrix.cpp
+++ b/example/matrix.cpp
@@ -118,21 +118,21 @@ void openmp(const std::vector<size_t>& D) {
   std::cout << "Generating matrix As ...\n";
   std::vector<matrix_t> As(D.size());
   #pragma omp parallel for
-  for(size_t j=0; j<D.size(); ++j) {
+  for(int j=0; j<D.size(); ++j) {
     As[j] = random_matrix(D[j]);
   }
   
   std::cout << "Generating matrix Bs ...\n";
   std::vector<matrix_t> Bs(D.size());
   #pragma omp parallel for
-  for(size_t j=0; j<D.size(); ++j) {
+  for(int j=0; j<D.size(); ++j) {
     Bs[j] = random_matrix(D[j]);
   }
   
   std::cout << "Computing matrix product values Cs ...\n";
   std::vector<matrix_t> Cs(D.size());
   #pragma omp parallel for
-  for(size_t j=0; j<D.size(); ++j) {
+  for(int j=0; j<D.size(); ++j) {
     Cs[j] = As[j] * Bs[j];
   }
 


### PR DESCRIPTION
Fixing compile for visual studio. Repaired the matrix example openmp "index must be signed integer" error, and fixed a if constexpr issue. It still has a huge amount of warnings.