### PR TITLE
Add multiple_dispatch example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,10 @@ add_executable(threadpool_cxx14 example/threadpool_cxx14.cpp)
 set_property(TARGET threadpool_cxx14 PROPERTY CXX_STANDARD 14)
 target_link_libraries(threadpool_cxx14 Threads::Threads)
 
+add_executable(multiple_dispatch example/multiple_dispatch.cpp)
+target_link_libraries(multiple_dispatch Threads::Threads)
+
+
 # -----------------------------------------------------------------------------
 # Unittest
 # -----------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -723,7 +723,7 @@ The folder `example/` contains several examples and is a great place to learn to
 | [debug.cpp](./example/debug.cpp)| inspects a taskflow through the dump method |
 | [emplace.cpp](./example/emplace.cpp)| demonstrates the difference between the emplace method and the silent_emplace method |
 | [matrix.cpp](./example/matrix.cpp) | creates two set of matrices and multiply each individually in parallel |
-| [multiple_dispatch.cpp](./example/multiple_dispatch.cpp) | illustrates dispatching multiple taskflow graphs as independent batches (which all run on the same taskpool) |
+| [multiple_dispatch.cpp](./example/multiple_dispatch.cpp) | illustrates dispatching multiple taskflow graphs as independent batches (which all run on the same threadpool) |
 | [parallel_for.cpp](./example/parallel_for.cpp)| parallelizes a for loop with unbalanced workload |
 | [reduce.cpp](./example/reduce.cpp)| performs reduce operations over linear containers |
 | [subflow.cpp](./example/subflow.cpp)| demonstrates how to create a subflow graph that spawns three dynamic tasks |

--- a/README.md
+++ b/README.md
@@ -723,10 +723,12 @@ The folder `example/` contains several examples and is a great place to learn to
 | [debug.cpp](./example/debug.cpp)| inspects a taskflow through the dump method |
 | [emplace.cpp](./example/emplace.cpp)| demonstrates the difference between the emplace method and the silent_emplace method |
 | [matrix.cpp](./example/matrix.cpp) | creates two set of matrices and multiply each individually in parallel |
+| [multiple_dispatch.cpp](./example/multiple_dispatch.cpp) | illustrates dispatching multiple taskflow graphs as independent batches (which all run on the same taskpool) |
 | [parallel_for.cpp](./example/parallel_for.cpp)| parallelizes a for loop with unbalanced workload |
 | [reduce.cpp](./example/reduce.cpp)| performs reduce operations over linear containers |
 | [subflow.cpp](./example/subflow.cpp)| demonstrates how to create a subflow graph that spawns three dynamic tasks |
-
+| [threadpool.cpp](./example/threadpool.cpp)| tests different threadpool implementations |
+| [threadpool_cxx14.cpp](./example/threadpool_cxx14.cpp)| shows use of the C++14-compatible threadpool implementation, which may be used when you have no inter-task (taskflow) dependencies to express |
 
 # Get Involved
 + Report bugs/issues by submitting a [Github issue][Github issues]
@@ -742,7 +744,7 @@ Cpp-Taskflow is being actively developed and contributed by the following people
 - [Nan Xiao](https://github.com/NanXiao) fixed compilation error of unittest on the Arch platform.
 - [Vladyslav](https://github.com/innermous) fixed comment errors in README.md and examples.
 - [vblanco20-1](https://github.com/vblanco20-1) fixed compilation error on Microsoft Visual Studio.
-- [Glen Fraser](https://github.com/totalgee) created a standalone C++14-compatible [threadpool](./taskflow/threadpool/threadpool_cxx14.hpp) for taskflow.
+- [Glen Fraser](https://github.com/totalgee) created a standalone C++14-compatible [threadpool](./taskflow/threadpool/threadpool_cxx14.hpp) for taskflow; various other fixes and examples.
 
 Meanwhile, we appreciate the support from many organizations for our development on Cpp-Taskflow.
 Please [let me know][email me] if I forgot someone!

--- a/example/multiple_dispatch.cpp
+++ b/example/multiple_dispatch.cpp
@@ -1,5 +1,5 @@
 // An example to show dispatching multiple Taskflow graphs as
-// separate batches (which will all run on the same Taskpool).
+// separate batches (which will all run on the same Threadpool).
 //
 // It first dispatches 5 "independent" tasks (#100-104),
 // then launches four batches (0-3) of a task graph with inter-dependencies,

--- a/example/multiple_dispatch.cpp
+++ b/example/multiple_dispatch.cpp
@@ -1,0 +1,81 @@
+// An example to show dispatching multiple Taskflow graphs as
+// separate batches (which will all run on the same Taskpool).
+//
+// It first dispatches 5 "independent" tasks (#100-104),
+// then launches four batches (0-3) of a task graph with inter-dependencies,
+// then it waits for the 100-104 tasks to finish before
+// launching 5 more independent tasks (#200-204).
+
+#include <taskflow/taskflow.hpp>
+
+void syncLog(std::string const& msg)
+{
+  static std::mutex logMutex;
+  std::lock_guard<std::mutex> lock(logMutex);
+  std::cout << msg << '\n';
+}
+
+void dispatchBatch(tf::Taskflow& tf, int batch)
+{
+  auto taskMaker = [](std::string const& taskName, int batch) {
+    return [=]() {
+      // Simulate some work
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      syncLog("  Batch " + std::to_string(batch) + " - done task " + taskName);
+    };
+  };
+  auto[A, B, C, D] = tf.silent_emplace(
+    taskMaker("A", batch),
+    taskMaker("B", batch),
+    taskMaker("C", batch),
+    taskMaker("D", batch)
+  );
+
+  A.precede(B);  // B runs after A
+  A.precede(C);  // C runs after A
+  B.precede(D);  // D runs after B
+  C.precede(D);  // D runs after C
+
+  // Schedule this independent graph of tasks (so they start running)
+  tf.silent_dispatch();
+}
+
+int main()
+{
+  tf::Taskflow tf(std::thread::hardware_concurrency());
+  auto const numIndependent = 5;
+  for (auto indTask = 100; indTask < 100 + numIndependent; ++indTask) {
+    tf.silent_emplace([=]() {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      syncLog("  Independent task " + std::to_string(indTask) + " - done");
+    });
+  }
+  syncLog("Dispatching " + std::to_string(numIndependent) + " independent tasks (100 range)");
+  auto independentTasksFuture = tf.dispatch();
+
+  auto const numBatches = 4;
+  for (auto batch = 0; batch < numBatches; ++batch) {
+    dispatchBatch(tf, batch);
+  }
+  syncLog(std::to_string(numBatches) + " batches (task graphs) dispatched");
+
+  // For some reason, we want to wait for the first set of
+  // "independent tasks" to finish before dispatching more
+  // of them...simulate that here:
+  independentTasksFuture.get();
+  syncLog("----- Independent tasks (100 range) completed");
+  for (auto indTask = 200; indTask < 200 + numIndependent; ++indTask) {
+    tf.silent_emplace([=]() {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      syncLog("  Independent task " + std::to_string(indTask) + " - done");
+    });
+  }
+  syncLog("Dispatching " + std::to_string(numIndependent) + " independent tasks (200 range)");
+  tf.silent_dispatch();
+
+  syncLog("Waiting for all...");
+  tf.wait_for_all();
+  syncLog("...all tasks finished");
+
+  return 0;
+}

--- a/unittest/threadpool.cpp
+++ b/unittest/threadpool.cpp
@@ -40,7 +40,7 @@ void test_async(ThreadpoolType& tp, const size_t task_num){
     int_future.emplace_back(tp.async(
       [size = i](){
         int sum = 0;
-        for(size_t i=0; i<=size; i++){
+        for(int i=0; i<=static_cast<int>(size); i++){
           sum += i;
         }       
         return sum;
@@ -83,7 +83,7 @@ void test_wait_for_all(ThreadpoolType& tp){
   REQUIRE(counter == task_num);
   REQUIRE(tp.num_workers() == 0);
 
-  tp.spawn(worker_num);
+  tp.spawn(static_cast<unsigned>(worker_num));
   REQUIRE(tp.num_workers() == worker_num);
 
   counter = 0;
@@ -107,7 +107,7 @@ TEST_CASE("SimpleThreadpool" * doctest::timeout(300)) {
   const size_t task_num = 100;
 
   SUBCASE("PlaceTask"){
-    for(size_t i=0; i<=4; ++i) {
+    for(unsigned i=0; i<=4; ++i) {
       tf::SimpleThreadpool tp(i);
       test_async(tp, task_num);
       test_silent_async(tp, task_num);
@@ -115,7 +115,7 @@ TEST_CASE("SimpleThreadpool" * doctest::timeout(300)) {
   }
   
   SUBCASE("WaitForAll"){
-    for(size_t i=0; i<=4; ++i) {
+    for(unsigned i=0; i<=4; ++i) {
       tf::SimpleThreadpool tp(i);
       test_wait_for_all(tp);
     }
@@ -130,7 +130,7 @@ TEST_CASE("ProactiveThreadpool" * doctest::timeout(300)) {
   const size_t task_num = 100;
 
   SUBCASE("PlaceTask"){
-    for(size_t i=0; i<=4; ++i) {
+    for(unsigned i=0; i<=4; ++i) {
       tf::ProactiveThreadpool tp(i);
       test_async(tp, task_num);
       test_silent_async(tp, task_num);
@@ -138,7 +138,7 @@ TEST_CASE("ProactiveThreadpool" * doctest::timeout(300)) {
   }
   
   SUBCASE("WaitForAll"){
-    for(size_t i=0; i<=4; ++i) {
+    for(unsigned i=0; i<=4; ++i) {
       tf::ProactiveThreadpool tp(i);
       test_wait_for_all(tp);
     }

--- a/unittest/threadpool_cxx14.cpp
+++ b/unittest/threadpool_cxx14.cpp
@@ -57,7 +57,7 @@ TEST_CASE("Threadpool.Basic" * doctest::timeout(5)) {
   tp.shutdown();
   REQUIRE(tp.num_workers() == 0);
 
-  tp.spawn(num_workers);
+  tp.spawn(static_cast<unsigned>(num_workers));
   REQUIRE(tp.num_workers() == num_workers);
 }
 


### PR DESCRIPTION
- add multiple_dispatch example, which illustrates dispatching
  multiple taskflow graphs as independent batches (which all run on
  the same taskpool).
- update README to include all recently-added examples.
- (unrelated) fix compile warnings on Visual Studio.