### PR TITLE
Add a ready-to-use generic class to associate data to the flows

### DIFF
--- a/example/dataflow.hpp
+++ b/example/dataflow.hpp
@@ -1,0 +1,228 @@
+#ifndef DATAFLOW_TPP_HPP
+#define DATAFLOW_TPP_HPP 1
+
+#include <taskflow/taskflow.hpp>
+
+#include <utility>
+#include <vector>
+#include <functional>
+
+namespace df {
+
+
+// "pads" are the object where functions on nodes can read from or write to;
+// pads are all of the same compile time type T.
+//
+// Class hierarchies and virtual functions can be used to have different types
+// of pads. In those cases, T would be probably a std::unique_ptr
+template <typename T>
+using Pad_id = typename std::vector<T>::size_type;
+
+
+// "nodes" corresponds to taskflow tasks, but are agumented with input and
+// output pads.
+template <typename T>
+class Node;
+template <typename T>
+using Node_id = typename std::vector< Node<T> >::size_type;
+
+
+// each node executes a "functor" of type Tranform_f passing itself as a
+// argument; the functor is expected to read from input pads and write to
+// output pads.
+template <typename T>
+using Transform_f = std::function<void(Node<T>& element)>;
+
+
+// "Dataflow_generator" is the type that keeps track of the relations between
+// nodes and their pads. See below for the interface.
+template <typename T>
+class Dataflow_generator;
+
+
+// Node interface, gives access to input and output pads.
+// For convenience output pads can be accessed with the [] operator
+template <typename T>
+class Node {
+public:
+    // get input pad
+    T const& ipad(Pad_id<T> id) const;
+
+    // get output pad
+    T& opad(Pad_id<T> id);
+    T& operator[](Pad_id<T>);
+
+    // get all the input pad ids
+    std::vector< Pad_id<T> > const& ipad_list() const;
+
+    // get all the output pad ids
+    std::vector< Pad_id<T> > const& opad_list() const;
+
+
+private:
+    std::vector<T>& pads_;
+    std::vector< Pad_id<T> > ipads_;
+    std::vector< Pad_id<T> > opads_;
+    Transform_f<T> compute_;
+
+    explicit Node(std::vector<T>& pads)
+      : pads_{pads},
+        ipads_{},
+        opads_{},
+        compute_{ nullptr } {}
+
+    friend class Dataflow_generator<T>;
+};
+
+
+// Dataflow generator interface, allows to:
+// . create nodes
+// . set up what each node executes
+// . create arcs
+// . execute the dag
+//
+// nodes are basically taskflow tasks agumented with input and output pads
+// edges are taskflow precedences
+// execution is done via taskflow taskflow.run_until
+template <typename T>
+class Dataflow_generator {
+public:
+    // creates a new node
+    Node_id<T> create_node();
+
+    // creates a new node and set up its functor
+    Node_id<T> create_node(Transform_f<T> f);
+
+    // creates a new arc ensuring that source output pads become the target
+    // input pads
+    Pad_id<T> create_arc(Node_id<T> source, Node_id<T> target);
+
+    // Set up the functor for an existing node
+    void set_function(Node_id<T> id, Transform_f<T> f);
+
+    // Peek to a node, it might be useful to see how many input or output pads
+    // it has
+    Node<T> const& node(Node_id<T> id) const;
+
+    // Executes the flow repeatly until the functor Cond returns true
+    template <typename Cond>
+    void start_flow(Cond && cond);
+
+    // Executes the flow once
+    void start_flow_once();
+
+    Dataflow_generator() = default;
+private:
+    std::vector<T> pads_;
+    std::vector< Node<T> > nodes_;
+    std::vector<tf::Task> tasks_;
+    tf::Framework executor_;
+};
+
+
+
+// Implementations
+
+template <typename T>
+T const&  Node<T>::
+ipad(Pad_id<T> id) const {
+    return pads_[id];
+}
+
+
+template <typename T>
+T&  Node<T>::
+opad(Pad_id<T> id) {
+    return pads_[id];
+}
+
+
+template <typename T>
+std::vector<Pad_id<T>> const&  Node<T>::
+ipad_list() const {
+    return ipads_;
+}
+
+
+template <typename T>
+std::vector<Pad_id<T>> const&  Node<T>::
+opad_list() const {
+    return opads_;
+}
+
+
+template <typename T>
+T& Node<T>::
+operator[](Pad_id<T> id) {
+    return pads_[id];
+}
+
+
+template <typename T>
+Node_id<T>  Dataflow_generator<T>::
+create_node() {
+    Node_id<T> node_id { nodes_.size() };
+
+    nodes_.emplace_back( Node(pads_) );
+    tasks_.emplace_back( executor_.emplace([this, node_id]() { this->nodes_[node_id].compute_( this->nodes_[node_id] ); }) );
+
+    return node_id;
+}
+
+
+template <typename T>
+Node_id<T>  Dataflow_generator<T>::
+create_node(Transform_f<T> f) {
+    Node_id<T> node_id { create_node() };
+    set_function(node_id, f);
+    return node_id;
+}
+
+
+template <typename T>
+Pad_id<T> Dataflow_generator<T>::
+create_arc(Node_id<T> source, Node_id<T> target) {
+    Pad_id<T> pad_id { pads_.size() };
+    pads_.emplace_back( T{} );
+
+    nodes_[source].opads_.push_back(pad_id);
+    nodes_[target].ipads_.push_back(pad_id);
+
+    tasks_[source].precede(tasks_[target]);
+
+    return pad_id;
+}
+
+
+template <typename T>
+template <typename Cond>
+void Dataflow_generator<T>::
+start_flow(Cond && cond) {
+    tf::Taskflow taskflow{};
+    taskflow.run_until(executor_, cond);
+}
+
+
+template <typename T>
+void Dataflow_generator<T>::
+start_flow_once() {
+    bool leave{true};
+    start_flow( [&leave]() { leave = !leave; return leave;} );
+}
+
+
+template <typename T>
+Node<T> const&  Dataflow_generator<T> ::
+node(Node_id<T> id) const {
+    return nodes_[id];
+}
+
+
+template <typename T>
+void  Dataflow_generator<T> ::
+set_function(Node_id<T> id, Transform_f<T> f) {
+    nodes_[id].compute_ = f;
+}
+
+}
+#endif

--- a/example/dataflow.hpp
+++ b/example/dataflow.hpp
@@ -1,5 +1,5 @@
-#ifndef DATAFLOW_TPP_HPP
-#define DATAFLOW_TPP_HPP 1
+#ifndef DATAFLOW_HPP
+#define DATAFLOW_HPP 1
 
 #include <taskflow/taskflow.hpp>
 

--- a/example/dice_pools.cpp
+++ b/example/dice_pools.cpp
@@ -5,23 +5,22 @@
 cpp-taskflow works on directed acyclic graphs.
 And here we want to pass information between the flow elements.
 
-To do so, we see the cpp-taskflow arcs as objects memory where the functions on
-the nodes read from or write to.
+To do so, we see the cpp-taskflow arcs as objects where the functions on the
+nodes read from or write to.
 
-The function on every node will *read from* the objects of memory of its
-incoming edges and *write to* the objects of its outcoming edges.
+The function on every node will *read from* the objects on the incoming arcs
+and *write to* the objects on the outcoming arcs.
 
 The cpp-taskflow semantics ensures the synchronization.
 
 
-Nodes without incoming edges will require the input from somewhere else;
-instead nodes without outcoming edges have to execute some side effects to be
-useful.
+Nodes without incoming arcs will require the input from somewhere else; instead
+nodes without outcoming arcs have to execute some side effects to be useful.
 
 
-In this example we fill up (in parallel) two vectors of the results of a fair
-percentile die and we pick up the maximum values from each cell, and output the
-result.
+In this example we fill up (in parallel) two vectors of the same size with the
+results of a fair percentile die, once done we pick up the maximum values from
+each cell. Finally we output the result.
 
 .----------------.
 | fill in vector |----|
@@ -38,7 +37,8 @@ The code assumes the taskflow is executed once, when using the Framework
 feature the programmer needs care to keep the invariants.
 
 It is then suggested to use const references (eg., vector<int> const&) for the
-objects related to the incoming arcs and references for outcoming ones.
+objects related to the incoming arcs and non-cost references for outcoming
+ones.
 
 */
 
@@ -94,7 +94,7 @@ public:
         for (std::vector<int>::size_type i{}, e = in1_.size(); i < e; ++i) {
             in1_[i] = std::max(in1_[i], in2_[i]);
         }
-        // the taskflow is executed once, so we avoid one copy
+        // the taskflow is executed once, so we avoid one allocation
         out_.swap(in1_);
     }
 private:
@@ -143,7 +143,7 @@ int main() {
         Print(out)
     );
 
-    // Set up dependencies
+    // Set up the dependencies
     fill_in_vector1.precede(pick_up_max);
     fill_in_vector2.precede(pick_up_max);
     pick_up_max.precede(print);

--- a/example/get_best_dice.cpp
+++ b/example/get_best_dice.cpp
@@ -1,0 +1,140 @@
+/*
+
+This example shows the usage of the dataflow template classes.
+
+Similarly to the percentile dice example, we have multiple dice pools, each
+contains 20 values, for each pool we want the maximum result of the position..
+
+So for each pool we throw 20 dice and fill up (in parallel) the vectors with
+the results, wait all the dice have been thrown, for each position in the
+vectors we pick up the maximum result, finally we write in stdout.
+
+So, with only one pool, on screen we will get 20 percentile results uniformily
+distributed. The more pools we use, the more the results will favor higher
+results.
+
+
+.----------------.
+| fill in vector |----|
+'----------------'    |
+...                  ...
+.----------------.    |
+| fill in vector |----|
+'----------------'    |->.-------------.     .-----------------.
+...                  ... | pick up max |---->| print in stdout |
+.----------------.    |->'-------------'     '-----------------'
+| fill in vector |----|
+'----------------'    |
+...                  ...
+.----------------.    |
+| fill in vector |----|
+'----------------'
+
+*/
+
+#include "dataflow.hpp"
+
+#include <vector>
+
+//All those includes are just to init the mersenne twister
+#include <array>
+#include <algorithm>
+#include <functional>
+#include <random>
+//until here
+
+
+// We set up all types
+using Dice_pool = std::vector<int>;
+
+using Dataflow_generator = df::Dataflow_generator<Dice_pool>;
+using Node = df::Node<Dice_pool>;
+
+using Pad_id = df::Pad_id<Dice_pool>;
+using Node_id = df::Node_id<Dice_pool>;
+using Transform_f = df::Transform_f<Dice_pool>;
+
+
+std::mt19937 init_mersenne_twister() {
+    std::array<std::uint32_t, std::mt19937::state_size> seed_bits{};
+    std::random_device real_random{};
+    std::generate(seed_bits.begin(), seed_bits.end(), std::ref(real_random));
+    std::seed_seq wrapped_seed_bits(seed_bits.begin(), seed_bits.end());
+
+    return std::mt19937(wrapped_seed_bits);
+}
+
+
+struct Fill_up_vector {
+    Fill_up_vector()
+      : rng_{ init_mersenne_twister() } {}
+
+    void operator()(Node& node) {
+        Node_id opad_id = node.opad_list()[0]; // This kind of nodes have exactly one output pad
+        Dice_pool& dice_pool = node.opad(opad_id);
+
+        dice_pool.resize(20);
+        std::uniform_int_distribution die(1,100);
+
+        for (auto& res : dice_pool) {
+            res = die( rng_ );
+        }
+    }
+
+    std::mt19937 rng_;
+};
+
+
+void pick_up_max(Node& node) {
+    std::vector<Node_id> const& dice_pool_ids = node.ipad_list(); // there can be many input pads
+    Node_id opad_id = node.opad_list()[0]; // Output pad
+
+    Dice_pool& best_results_pool = node.opad(opad_id);
+    best_results_pool.resize(20);
+
+    for (std::size_t i{}, e{20}; i < e; ++i) {
+        int maximum{ -1 };
+        for (Node_id dice_pool_id: dice_pool_ids) {
+            if (node.ipad(dice_pool_id)[i] > maximum) {
+                maximum = node.ipad(dice_pool_id)[i];
+            }
+        }
+        best_results_pool[i] = maximum;
+    }
+}
+
+
+void write_out(Node& node) {
+    Node_id ipad_id = node.ipad_list()[0]; // The input pad
+    Dice_pool const& best_results_pool = node.ipad(ipad_id);
+
+    bool first{ true };
+    for (auto const& result : best_results_pool) {
+        if (first) {
+            first = false;
+        } else {
+            std::cout << ", ";
+        }
+        std::cout << result;
+    }
+    std::cout << "\n";
+}
+
+
+int main() {
+    Dataflow_generator gg{};
+
+    auto output = gg.create_node(write_out);
+    auto pickup = gg.create_node(pick_up_max);
+    gg.create_arc(pickup, output);
+
+    //try to increase or reduce the number of dice pools
+    int nr_dice_pools{ 5 };
+    while (nr_dice_pools-- > 0) {
+        gg.create_arc(gg.create_node(Fill_up_vector{}), pickup);
+    }
+
+    int times{ 10 };
+    gg.start_flow([&times]() { return times-- == 0; });
+}
+


### PR DESCRIPTION
The class is a thin wrapper around taskflow that ensures that each arc in the taskflow DAG has a associated object (of type T) and allows nodes to execute a function that can easily read from the incoming arcs objects and write in the outcoming arcs objects.

All arcs are associated with an object of the same type T. Since the graph is built runtime it would be really difficult to do otherwise. If one needs different types of objects on the arcs, then one can use class hierarchies and virtual functions and the type T would be a unique_ptr<some base class>. Otherwise one can use std::variant.

The new example is an extension of the previous one. It wants to show that with a bit of boiler plate code that give human-readable names to the objects on the incoming and outcoming arcs it is possible to have readable parallel functions, with input and output, synchronized by the taskflow semantics.

I also renamed my previous example and fix the English language a bit.