### PR TITLE
fix: empty composed taskflow was causing executor to block

### DIFF
--- a/taskflow/core/executor.hpp
+++ b/taskflow/core/executor.hpp
@@ -510,7 +510,7 @@ inline void Executor::_schedule_unsync(
 ) const {
   
   // module node need another initialization
-  if(node->_module != nullptr && !node->is_spawned()) {
+  if(node->_module != nullptr && !node->_module->empty() && !node->is_spawned()) {
     _init_module_node_unsync(node, stack);
   }
 
@@ -526,7 +526,7 @@ inline void Executor::_schedule_unsync(
   // here we guarantee to run by a thread so no need to cache the
   // size from nodes
   for(auto node : nodes) {
-    if(node->_module != nullptr && !node->is_spawned()) {
+    if(node->_module != nullptr && !node->_module->empty() && !node->is_spawned()) {
       _init_module_node_unsync(node, stack);
     }
     stack.push(node);
@@ -541,7 +541,7 @@ inline void Executor::_schedule(Node* node, bool bypass) {
   assert(_workers.size() != 0);
   
   // module node need another initialization
-  if(node->_module != nullptr && !node->is_spawned()) {
+  if(node->_module != nullptr && !node->_module->empty() && !node->is_spawned()) {
     _init_module_node(node);
   }
   
@@ -582,7 +582,7 @@ inline void Executor::_schedule(PassiveVector<Node*>& nodes) {
   }
 
   for(auto node : nodes) {
-    if(node->_module != nullptr && !node->is_spawned()) {
+    if(node->_module != nullptr && !node->_module->empty() && !node->is_spawned()) {
       _init_module_node(node);
     }
   }


### PR DESCRIPTION
Minimal example of the bug:

```
    tf::Taskflow flowA, flowB;
    tf::Executor executor;
    flowA.composed_of(flowB);
    executor.run(flowA).wait();
```

I'm not really sure, I've fixed it the "proper way" as I don't have much experience with your codebase, but it did fix the bug for me.