### PR TITLE
remove extra semicolon

### DIFF
--- a/taskflow/utility/object_pool.hpp
+++ b/taskflow/utility/object_pool.hpp
@@ -23,7 +23,7 @@ namespace tf {
 
 #define TF_ENABLE_POOLABLE_ON_THIS                          \
   template <typename T, size_t S> friend class ObjectPool;  \
-  void* _object_pool_block;
+  void* _object_pool_block
 
 // Class: ObjectPool
 //


### PR DESCRIPTION
Fix gcc-9 -Wpedantic warning about extra semicolon. All uses have a
semicolon at the end so remove from the macro.